### PR TITLE
Add Tekton manifests

### DIFF
--- a/.github/tekton/README.md
+++ b/.github/tekton/README.md
@@ -1,0 +1,25 @@
+# KS Repo CI/CD
+
+Why dose `ks-releaser` project have a folder `.github/tekton`? Because we want to replace GitHub workflow with Tekton.
+
+We dogfood our project by using Tekton Pipelines to build and test `ks-releaser`. This directory contains the [Tasks](https://tekton.dev/docs/pipelines/tasks/), [Pipelines](https://tekton.dev/docs/pipelines/pipelines/) and [Triggers](https://tekton.dev/docs/triggers/) that we use.
+
+## Tekton manifests
+
+| Manifest                           | Description                                                                        |
+| ---------------------------------- | ---------------------------------------------------------------------------------- |
+| build-bot.yaml                     | Needed by `PipelineRun`. For more granularity in specifying execution credentials. |
+| shared-storage.yaml                | Share volume among tasks. Such as source code output from `git-clone` task.        |
+| pull-request-pipeline.yaml         | `Pipeline` configuration for ks when pull request event is comming.                |
+| pull-request-trigger.yaml          | Indicate what happens when the EventListener detects an event.                     |
+| pull-request-trigger-template.yaml | Specifies a blueprint for PipelineRun.                                             |
+
+## FAQ
+
+- How to use common task?
+
+  We hosted all common tasks in [ks-infra](https://github.com/kubesphere-sigs/ks-infra), and they have been listed [here](https://github.com/kubesphere-sigs/ks-infra/tree/master/prod/ks-devops-ext-tekton-common#common-tasks).
+
+- How to contribute a common task?
+
+  If you want to use a task, and the task is very general, you are welcome to add it [here](https://github.com/kubesphere-sigs/ks-infra/tree/master/prod/ks-devops-ext-tekton-common#common-tasks) first. Argo CD will automatically syncrhonize it into corresponding cluster.

--- a/.github/tekton/build-bot.yaml
+++ b/.github/tekton/build-bot.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ks-releaser-build-bot
+secrets:
+  - name: codecov-token

--- a/.github/tekton/pull-request-pipeline.yaml
+++ b/.github/tekton/pull-request-pipeline.yaml
@@ -1,0 +1,138 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: ks-releaser-pull-request
+spec:
+  workspaces:
+    - name: repo
+  params:
+    - name: repo-full-name
+      description: "Repository full name. like: kubesphere-sigs/ks-releaser"
+    - name: clone-url
+      description: Repository URL to clone from.
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      default: master
+    - name: dashboard-url
+      description: Tekton dashboard access URL, like http://demo:31962/#/namespaces/ks/pipelineruns.
+  tasks:
+    - name: set-running-status
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.repo-full-name)
+        - name: SHA
+          value: $(params.revision)
+        - name: DESCRIPTION
+          value: Build has started
+        - name: STATE
+          value: pending
+        - name: TARGET_URL
+          value: $(params.dashboard-url)
+    - name: checkout
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: $(params.clone-url)
+        - name: revision
+          value: $(params.revision)
+      workspaces:
+        - name: output
+          workspace: repo
+    - name: build
+      runAfter:
+        - checkout
+      taskRef:
+        name: goreleaser-and-trivy
+      params:
+        # Goreleaser part
+        - name: package
+          value: github.com/kubesphere-sigs/ks-releaser
+        - name: flags
+          value: --skip-publish --rm-dist --debug --snapshot
+        # Trivy scanner part
+        - name: IMAGE_PATH
+          value: ghcr.io/kubesphere-sigs/ks-releaser:latest
+        - name: ARGS
+          value:
+            - image
+            - --severity HIGH,CRITICAL
+            - --vuln-type os,library
+            - --exit-code 1
+            - --no-progress
+            - --ignore-unfixed
+            - --format table
+      workspaces:
+        - name: source
+          workspace: repo
+    - name: test
+      runAfter:
+        - checkout
+      taskSpec:
+        steps:
+          - name: run-test
+            image: golang:1.16-alpine3.14
+            workingDir: $(workspaces.source.path)
+            script: |
+              apk --no-cache --update add build-base
+              go test ./... -coverprofile coverage.out
+        workspaces:
+          - name: source
+      workspaces:
+        - name: source
+          workspace: repo
+    - name: codecov
+      runAfter:
+        - test
+      taskRef:
+        name: codecov
+      params:
+        - name: args
+          value:
+            - -n codecov-umbrella 
+            - -F unittests 
+            - -Q github-action-v1.5.2
+            - -f coverage.out
+            - -Z 
+      workspaces:
+        - name: source
+          workspace: repo
+  finally:
+    - name: set-pull-request-failure
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.repo-full-name)
+        - name: SHA
+          value: $(params.revision)
+        - name: DESCRIPTION
+          value: Build has failed
+        - name: STATE
+          value: failure
+        - name: TARGET_URL
+          value: $(params.dashboard-url)
+    - name: set-pull-request-success
+      when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Succeeded", "Completed"]
+      taskRef:
+        name: github-set-status
+      params:
+        - name: REPO_FULL_NAME
+          value: $(params.repo-full-name)
+        - name: SHA
+          value: $(params.revision)
+        - name: DESCRIPTION
+          value: Build has executed successfully
+        - name: STATE
+          value: success
+        - name: TARGET_URL
+          value: $(params.dashboard-url)

--- a/.github/tekton/pull-request-trigger-template.yaml
+++ b/.github/tekton/pull-request-trigger-template.yaml
@@ -1,0 +1,33 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: TriggerTemplate
+metadata:
+  name: ks-releaser-pull-request
+spec:
+  params:
+    - name: repo-full-name
+    - name: revision
+    - name: clone-url
+    - name: pull-request-number
+    - name: dashboard-url
+  resourcetemplates:
+    - apiVersion: tekton.dev/v1beta1
+      kind: PipelineRun
+      metadata:
+        name: ks-releaser-pull-request-$(tt.params.pull-request-number)-$(uid)
+      spec:
+        serviceAccountName: ks-releaser-build-bot
+        pipelineRef:
+          name: ks-releaser-pull-request
+        params:
+          - name: clone-url
+            value: $(tt.params.clone-url)
+          - name: revision
+            value: $(tt.params.revision)
+          - name: repo-full-name
+            value: $(tt.params.repo-full-name)
+          - name: dashboard-url
+            value: $(tt.params.dashboard-url)/ks-releaser-pull-request-$(tt.params.pull-request-number)-$(uid)
+        workspaces:
+          - name: repo
+            persistentVolumeClaim:
+              claimName: ks-releaser-source-shared-storage

--- a/.github/tekton/pull-request-trigger.yaml
+++ b/.github/tekton/pull-request-trigger.yaml
@@ -1,0 +1,31 @@
+apiVersion: triggers.tekton.dev/v1beta1
+kind: Trigger
+metadata:
+  name: ks-releaser-pull-request
+spec:
+  interceptors:
+    - ref:
+        name: github
+      params:
+        - name: secretRef
+          value:
+            secretName: webhook-secret
+            secretKey: secret
+        - name: eventTypes
+          value:
+            - pull_request
+    - ref:
+        name: cel
+      params:
+        - name: filter
+          value: "body.action in ['opened', 'synchronize', 'reopened']"
+    - ref:
+        name: cel
+      params:
+        - name: filter
+          value: "body.repository.full_name == 'kubesphere-sigs/ks-releaser'"
+  bindings:
+    - ref: pipeline-clusterbinding
+      kind: ClusterTriggerBinding
+  template:
+    ref: ks-releaser-pull-request

--- a/.github/tekton/shared-storage.yaml
+++ b/.github/tekton/shared-storage.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ks-releaser-source-shared-storage
+spec:
+  resources:
+    requests:
+      storage: 16Mi
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteOnce

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
### What this PR dose / Why we need it

Add Tekton manifests, including
- ServiceAccount for PipelineRun
- Shared storage
- Pipeline
- Trigger Template
- Trigger

Some common manifests will be hosted at [ks-infra](https://github.com/kubesphere-sigs/ks-infra), please see upstream PR: https://github.com/kubesphere-sigs/ks-infra/pull/6.

BTW, I also disabled GitHub workflow for pull request.

/kind feature
/cc @kubesphere-sigs/sig-devops 