### PR TITLE
Reduce length of pipeline run name

### DIFF
--- a/.github/tekton/pull-request-trigger-template.yaml
+++ b/.github/tekton/pull-request-trigger-template.yaml
@@ -13,7 +13,10 @@ spec:
     - apiVersion: tekton.dev/v1beta1
       kind: PipelineRun
       metadata:
-        name: ks-releaser-pull-request-$(tt.params.pull-request-number)-$(uid)
+        # The max length of the name is 63, and the length of the $(uid) is 36.
+        # So the length of the prefix name must be equal to or less than 27.
+        # We assume the length of pull-request-number won't be greater than 12.
+        name: ks-releaser-pr-$(tt.params.pull-request-number)-$(uid)
       spec:
         serviceAccountName: ks-releaser-build-bot
         pipelineRef:


### PR DESCRIPTION
This change would fix an error fired by `event-listener`: **validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name**.

```json
{
  "level": "error",
  "ts": "2021-12-21T07:53:07.221Z",
  "logger": "eventlistener",
  "caller": "sink/sink.go:436",
  "msg": "problem creating obj: &errors.errorString{s:\"couldn't create resource with group version kind \\\"tekton.dev/v1beta1, Resource=pipelineruns\\\": admission webhook \\\"validation.webhook.pipeline.tekton.dev\\\" denied the request: validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name\"}",
  "eventlistener": "trigger-listener",
  "namespace": "ks-devops-ext",
  "eventlistenerUID": "5ed45998-6540-4815-a578-0fba13d12923",
  "/triggers-eventid": "3e5d39fb-3e18-476d-903a-f85c94a2199d",
  "/trigger": "ks-releaser-pull-request",
  "stacktrace": "github.com/tektoncd/triggers/pkg/sink.Sink.CreateResources\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:436\ngithub.com/tektoncd/triggers/pkg/sink.Sink.processTrigger\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:326\ngithub.com/tektoncd/triggers/pkg/sink.Sink.HandleEvent.func1\n\tgithub.com/tektoncd/triggers/pkg/sink/sink.go:139"
}
 ```
/kind bug