### PR TITLE
Correct dahsboard-url parameter

### DIFF
--- a/.github/tekton/pull-request-trigger-template.yaml
+++ b/.github/tekton/pull-request-trigger-template.yaml
@@ -29,7 +29,7 @@ spec:
           - name: repo-full-name
             value: $(tt.params.repo-full-name)
           - name: dashboard-url
-            value: $(tt.params.dashboard-url)/ks-releaser-pull-request-$(tt.params.pull-request-number)-$(uid)
+            value: $(tt.params.dashboard-url)/ks-releaser-pr-$(tt.params.pull-request-number)-$(uid)
         workspaces:
           - name: repo
             persistentVolumeClaim:


### PR DESCRIPTION
The value configuration should be equal to 
https://github.com/kubesphere-sigs/ks-releaser/blob/2001058d44082884c5542e7b716132426f28021e/.github/tekton/pull-request-trigger-template.yaml#L19
/kind bug